### PR TITLE
🎨 Palette: Add ARIA state to mobile menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Portfolio Projects/eaa.html
+++ b/Portfolio Projects/eaa.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -61,13 +61,22 @@
 
     <script src="../script.js"></script>
     <script>
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project1.html
+++ b/Portfolio Projects/project1.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -46,13 +46,22 @@
 
     <script src="../script.js"></script>
     <script>
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project3.html
+++ b/Portfolio Projects/project3.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -46,13 +46,22 @@
 
     <script src="../script.js"></script>
     <script>
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project4.html
+++ b/Portfolio Projects/project4.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -46,13 +46,22 @@
 
     <script src="../script.js"></script>
     <script>
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project5.html
+++ b/Portfolio Projects/project5.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -46,13 +46,22 @@
 
     <script src="../script.js"></script>
     <script>
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project6.html
+++ b/Portfolio Projects/project6.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -46,13 +46,22 @@
 
     <script src="../script.js"></script>
     <script>
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/about.html
+++ b/about.html
@@ -18,8 +18,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -51,14 +51,23 @@
     </footer>
     <script>
         // Mobile menu toggle
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/bookings.html
+++ b/bookings.html
@@ -190,8 +190,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>

--- a/contact.html
+++ b/contact.html
@@ -175,8 +175,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>

--- a/galleries.html
+++ b/galleries.html
@@ -313,8 +313,8 @@
     <div class="header-left">
       <h1 class="header-title">Caleb Stone</h1>
     </div>
-    <button class="header-menu-btn" aria-label="Menu">Menu</button>
-    <nav class="header-nav">
+    <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+    <nav class="header-nav" id="mobile-menu">
       <a href="index.html">Home</a>
       <a href="about.html">About</a>
       <a href="galleries.html">Galleries</a>
@@ -809,18 +809,27 @@
   <script src="script.js"></script>
   <script>
     // Mobile menu toggle
-    document.querySelector('.header-menu-btn').onclick = function () {
-      document.querySelector('.header-nav').classList.toggle('show');
-    };
+    const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
 
     // Close mobile menu on link click
     document.querySelectorAll('.header-nav a').forEach(link => {
-      link.onclick = () => {
-        if (window.innerWidth <= 700) {
-          document.querySelector('.header-nav').classList.remove('show');
-        }
-      };
-    });
+            link.onclick = () => {
+                if (window.innerWidth <= 700) {
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
+                }
+            };
+        });
 
     // Gallery page navigation
     document.querySelectorAll('.gallery-nav').forEach(nav => {

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
     <div class="header-left">
       <h1 class="header-title">Caleb Stone</h1>
     </div>
-    <button class="header-menu-btn" aria-label="Menu">Menu</button>
-    <nav class="header-nav">
+    <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+    <nav class="header-nav" id="mobile-menu">
       <a href="index.html">Home</a>
       <a href="about.html">About</a>
       <a href="galleries.html">Galleries</a>

--- a/portfolio.html
+++ b/portfolio.html
@@ -18,8 +18,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -106,14 +106,23 @@
     <script src="script.js"></script>
     <script>
         // Mobile menu toggle
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 1350) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/pricing.html
+++ b/pricing.html
@@ -28,8 +28,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav class="header-nav" id="mobile-menu">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -166,14 +166,23 @@
     <script src="script.js"></script>
     <script>
         // Mobile menu toggle
-        document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
-        };
+        const menuBtn = document.querySelector('.header-menu-btn');
+        const nav = document.querySelector('.header-nav');
+        if (menuBtn && nav) {
+            menuBtn.onclick = function () {
+                nav.classList.toggle('show');
+                const isExpanded = nav.classList.contains('show');
+                menuBtn.setAttribute('aria-expanded', isExpanded);
+            };
+        }
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
-                    document.querySelector('.header-nav').classList.remove('show');
+                    const nav = document.querySelector('.header-nav');
+                    const menuBtn = document.querySelector('.header-menu-btn');
+                    if (nav) nav.classList.remove('show');
+                    if (menuBtn) menuBtn.setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/script.js
+++ b/script.js
@@ -151,6 +151,8 @@ document.addEventListener('DOMContentLoaded', function() {
 	if (menuBtn && nav) {
 		menuBtn.onclick = function() {
 			nav.classList.toggle('show');
+			const isExpanded = nav.classList.contains('show');
+			menuBtn.setAttribute('aria-expanded', isExpanded);
 		};
 
 		// Close menu when clicking a link (on mobile)
@@ -158,6 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
 			link.onclick = () => {
 				if (window.innerWidth <= 700) {
 					nav.classList.remove('show');
+					menuBtn.setAttribute('aria-expanded', 'false');
 				}
 			};
 		});


### PR DESCRIPTION
This PR improves the accessibility of the mobile navigation menu across the site.

The `.header-menu-btn` button lacked ARIA attributes to announce its state to screen readers. This update adds `aria-expanded="false"` and `aria-controls="mobile-menu"` to the button in all HTML files, and `id="mobile-menu"` to the `.header-nav` container. 

The global `script.js` and inline scripts in specific HTML files have been updated to dynamically toggle the `aria-expanded` state to `true` when the menu is opened, and `false` when it is closed (either by clicking the toggle again or selecting a link).

No visual changes were made, ensuring existing design patterns remain intact. Code was linted and verified functional via Playwright tests.

---
*PR created automatically by Jules for task [5733172462899874250](https://jules.google.com/task/5733172462899874250) started by @calebstone15*