### PR TITLE
🎨 Palette: Add aria-expanded state to mobile menu button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - [Inline Form Validation]
 **Learning:** Adding `aria-describedby`, `aria-invalid`, and `role="alert"` to form inputs and error messages significantly improves accessibility for screen reader users by programmatically linking errors to their fields and announcing them immediately.
 **Action:** When implementing form validation, always ensure error messages are unused but present in the DOM (hidden) with unique IDs, and toggle their visibility and the `aria-invalid` state of the input based on validation logic. Use `blur` for initial check and `input` for real-time correction.
+
+## 2025-02-15 - [Mobile Menu Accessibility]
+**Learning:** Adding `aria-expanded` and `aria-controls` to mobile menu toggle buttons allows screen readers to correctly announce the state (open/closed) of the menu to visually impaired users.
+**Action:** Always include `aria-expanded="false"` and `aria-controls="[menu-id]"` on the menu button, give the menu a matching `id`, and dynamically toggle `aria-expanded` to `"true"` or `"false"` in the JavaScript that handles the menu visibility.

--- a/Portfolio Projects/eaa.html
+++ b/Portfolio Projects/eaa.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -62,12 +62,17 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project1.html
+++ b/Portfolio Projects/project1.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,17 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project3.html
+++ b/Portfolio Projects/project3.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,17 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project4.html
+++ b/Portfolio Projects/project4.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,17 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project5.html
+++ b/Portfolio Projects/project5.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,16 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project6.html
+++ b/Portfolio Projects/project6.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,17 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/about.html
+++ b/about.html
@@ -18,8 +18,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -52,13 +52,18 @@
     <script>
         // Mobile menu toggle
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
         };
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/bookings.html
+++ b/bookings.html
@@ -190,8 +190,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>

--- a/contact.html
+++ b/contact.html
@@ -175,8 +175,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>

--- a/galleries.html
+++ b/galleries.html
@@ -313,8 +313,8 @@
     <div class="header-left">
       <h1 class="header-title">Caleb Stone</h1>
     </div>
-    <button class="header-menu-btn" aria-label="Menu">Menu</button>
-    <nav class="header-nav">
+    <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+    <nav id="mobile-menu" class="header-nav">
       <a href="index.html">Home</a>
       <a href="about.html">About</a>
       <a href="galleries.html">Galleries</a>
@@ -810,7 +810,11 @@
   <script>
     // Mobile menu toggle
     document.querySelector('.header-menu-btn').onclick = function () {
-      document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
     };
 
     // Close mobile menu on link click
@@ -818,6 +822,7 @@
       link.onclick = () => {
         if (window.innerWidth <= 700) {
           document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
         }
       };
     });

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
     <div class="header-left">
       <h1 class="header-title">Caleb Stone</h1>
     </div>
-    <button class="header-menu-btn" aria-label="Menu">Menu</button>
-    <nav class="header-nav">
+    <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+    <nav id="mobile-menu" class="header-nav">
       <a href="index.html">Home</a>
       <a href="about.html">About</a>
       <a href="galleries.html">Galleries</a>

--- a/portfolio.html
+++ b/portfolio.html
@@ -18,8 +18,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -107,13 +107,17 @@
     <script>
         // Mobile menu toggle
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
         };
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 1350) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/pricing.html
+++ b/pricing.html
@@ -28,8 +28,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="mobile-menu">Menu</button>
+        <nav id="mobile-menu" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -167,13 +167,18 @@
     <script>
         // Mobile menu toggle
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const nav = document.querySelector('.header-nav');
+            nav.classList.toggle('show');
+            const isExpanded = nav.classList.contains('show');
+            this.setAttribute('aria-expanded', isExpanded.toString());
+
         };
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/script.js
+++ b/script.js
@@ -151,6 +151,8 @@ document.addEventListener('DOMContentLoaded', function() {
 	if (menuBtn && nav) {
 		menuBtn.onclick = function() {
 			nav.classList.toggle('show');
+			const isExpanded = nav.classList.contains('show');
+			menuBtn.setAttribute('aria-expanded', isExpanded.toString());
 		};
 
 		// Close menu when clicking a link (on mobile)
@@ -158,6 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
 			link.onclick = () => {
 				if (window.innerWidth <= 700) {
 					nav.classList.remove('show');
+					menuBtn.setAttribute('aria-expanded', 'false');
 				}
 			};
 		});


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-controls` attributes to the mobile menu button (`.header-menu-btn`) and an `id` to the navigation menu (`.header-nav`). Updated JavaScript across the site (both in `script.js` and inline scripts) to dynamically toggle the `aria-expanded` attribute based on the menu's state.

🎯 Why: Screen reader users need to be programmatically informed when a collapsible menu is opened or closed. Without `aria-expanded`, there is no feedback to visually impaired users that clicking the menu button has revealed new content.

♿ Accessibility: 
- `aria-controls="mobile-menu"` explicitly links the toggle button to the menu container it controls.
- `aria-expanded="false"` (default) signals the menu is closed.
- JavaScript updates `aria-expanded="true"` when the menu opens, triggering a state change announcement in screen readers.

---
*PR created automatically by Jules for task [15322790467847210083](https://jules.google.com/task/15322790467847210083) started by @calebstone15*