### PR TITLE
⚡ Bolt: Replace expensive scroll listener with IntersectionObserver

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-05-18 - Array Search and Allocation Performance
 **Learning:** Using `[...arr].reverse().findIndex()` to find the last index is an anti-pattern. It creates a full copy of the array and reverses it, which is O(N) memory and time. Use `arr.lastIndexOf()` instead for primitive types or simple predicates.
 **Action:** Scan for usage of `.reverse()` on array copies used solely for finding indices. Replace with `lastIndexOf` or a reverse loop.
+
+## 2025-05-18 - Scroll Event Listeners for Visibility Checks
+**Learning:** Attaching synchronous `scroll` event listeners that query the DOM (e.g., `querySelectorAll`) and calculate layout (`getBoundingClientRect`) causes severe main thread blocking and layout thrashing (jank) during scrolling. Furthermore, implementing custom JS logic for lazy loading images when native `loading="lazy"` is already present is redundant and computationally wasteful.
+**Action:** Always replace synchronous scroll listeners for visibility checks with `IntersectionObserver`, which utilizes native browser optimizations for viewport intersection detection without blocking the main thread. Rely on native `loading="lazy"` for images whenever possible.

--- a/galleries.html
+++ b/galleries.html
@@ -889,43 +889,25 @@
         };
       });
 
-      // Lazy load images for later pages
-      function lazyLoadGalleryImages() {
-        document.querySelectorAll('.gallery-item[data-page]:not([data-page="1"])').forEach(item => {
-          const img = item.querySelector('img');
-          if (img && !img.dataset.lazyLoaded) {
-            // Set src attribute only when nearing viewport
-            img.setAttribute('loading', 'lazy');
-            img.dataset.lazyLoaded = 'true';
+      // ⚡ Bolt: Replace expensive scroll listener with IntersectionObserver
+      // This prevents layout thrashing (getBoundingClientRect) and main thread
+      // blocking on every scroll frame by utilizing native browser optimizations.
+      const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            obs.unobserve(entry.target); // Stop observing once visible
           }
         });
-      }
-
-      // Call lazy load on scroll and resize
-      window.addEventListener('scroll', lazyLoadGalleryImages);
-      window.addEventListener('resize', lazyLoadGalleryImages);
-
-      // Initial call for images that might be visible
-      lazyLoadGalleryImages();
-    });
-
-    // Scroll animation - show sections when scrolled into view
-    function checkScroll() {
-      const sections = document.querySelectorAll('.gallery-section');
-
-      sections.forEach(section => {
-        const sectionTop = section.getBoundingClientRect().top;
-        const windowHeight = window.innerHeight;
-
-        if (sectionTop < windowHeight * 0.8) {
-          section.classList.add('visible');
-        }
+      }, {
+        rootMargin: '0px 0px -20% 0px', // Trigger when section is 20% into view (similar to < windowHeight * 0.8)
+        threshold: 0
       });
-    }
 
-    // Check scroll position on load and scroll
-    window.addEventListener('load', checkScroll);
-    window.addEventListener('scroll', checkScroll);
+      document.querySelectorAll('.gallery-section').forEach(section => {
+        observer.observe(section);
+      });
+    });
   </script>
 </body>
 


### PR DESCRIPTION
## 💡 What
Replaced the synchronous `checkScroll` function and its associated window `scroll` event listener with a native `IntersectionObserver` in `galleries.html`. Also removed the `lazyLoadGalleryImages` function entirely, as it was redundant.

## 🎯 Why
The previous implementation attached an event listener to the `scroll` and `resize` events that ran a `forEach` loop across multiple DOM elements, calculating `getBoundingClientRect()` synchronously on every frame. This is a classic cause of scroll jank, main thread blocking, and layout thrashing. Furthermore, the `lazyLoadGalleryImages` function implemented custom JS logic to append the `loading="lazy"` attribute, which the images already had coded directly in the HTML.

## 📊 Impact
Eliminates O(N) DOM querying and expensive layout recalculations (`getBoundingClientRect`) per scroll frame. Scrolling the gallery on a mobile device or lower-end machine should now be perfectly smooth, as viewport visibility calculations are offloaded to the browser's optimized asynchronous rendering pipeline.

## 🔬 Measurement
Verified via playwright scrolling tests that elements properly gain the `.visible` class when scrolled into view exactly as they did before, but without any scroll listeners attached.

---
*PR created automatically by Jules for task [8087262447542120567](https://jules.google.com/task/8087262447542120567) started by @calebstone15*