### PR TITLE
⚡ Bolt: [performance improvement] Replace redundant parsing with cached numeric array retrievals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-05-18 - Array Search and Allocation Performance
 **Learning:** Using `[...arr].reverse().findIndex()` to find the last index is an anti-pattern. It creates a full copy of the array and reverses it, which is O(N) memory and time. Use `arr.lastIndexOf()` instead for primitive types or simple predicates.
 **Action:** Scan for usage of `.reverse()` on array copies used solely for finding indices. Replace with `lastIndexOf` or a reverse loop.
+## 2025-05-18 - Redundant Data Parsing
+**Learning:** In `hotfire-analyzer.js`, `getColumnData` and `getTotalThrust` were redundantly parsing string rows to numbers instead of using the cached numeric arrays (`ctx.getNumericColumn()`), creating O(N) redundant operations per column lookup.
+**Action:** Use cached pre-parsed numeric data when computing metrics or plotting to improve performance.

--- a/EAA Web Version/js/hotfire-analyzer.js
+++ b/EAA Web Version/js/hotfire-analyzer.js
@@ -316,19 +316,23 @@ function displayMetrics() {
 
 function getColumnData(colName) {
     if (!ctx.df || !colName) return [];
-    return ctx.df.map(row => Utils.parseNumber(row[colName]));
+    return ctx.getNumericColumn(colName);
 }
 
 function getTotalThrust() {
     if (ctx.thrustCols.length === 0) return [];
-    return ctx.df.map(row => {
+    const len = ctx.df.length;
+    const thrustColsData = ctx.thrustCols.map(col => ctx.getNumericColumn(col));
+    const result = new Array(len);
+    for (let i = 0; i < len; i++) {
         let sum = 0;
-        for (const col of ctx.thrustCols) {
-            const val = Utils.parseNumber(row[col]);
+        for (let j = 0; j < thrustColsData.length; j++) {
+            const val = thrustColsData[j][i];
             if (!isNaN(val)) sum += val;
         }
-        return sum;
-    });
+        result[i] = sum;
+    }
+    return result;
 }
 
 // ============================================


### PR DESCRIPTION
💡 **What**: Refactored `getColumnData` and `getTotalThrust` in `hotfire-analyzer.js` to utilize the pre-existing `ctx.getNumericColumn()` cache instead of parsing raw row strings with `Utils.parseNumber` in local loops.
🎯 **Why**: Previously, functions calculating column data and total thrust would iterate through the raw `ctx.df` and parse strings into numbers repeatedly (O(N) operation per column). This change leverages the `numericCache` built into `AnalyzerContext`, eliminating redundant parsing and memory allocation by fetching pre-parsed numeric data.
📊 **Impact**: Reduces CPU cycles and memory allocations significantly during plot generation and metrics calculation, especially on large dataset windows. Replaces repeated string-to-number mapping with simple arithmetic over cached arrays.
🔬 **Measurement**: Verified the logic in a sandboxed Node `vm` environment mimicking the app's state. `pnpm dlx eslint@8` runs cleanly except for a pre-existing modern syntax feature. The test suite correctly executed the behavior.

---
*PR created automatically by Jules for task [13430227690528645488](https://jules.google.com/task/13430227690528645488) started by @calebstone15*