### PR TITLE
🎨 Palette: Add ARIA states to mobile menu toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - [Add ARIA states to mobile menu]
+**Learning:** The mobile menu toggle (`.header-menu-btn`) lacked `aria-expanded` and `aria-controls` attributes, and its state was not synchronized dynamically when toggling the menu, which is critical for screen reader users to understand when the menu opens or closes.
+**Action:** Added `aria-controls="header-nav"` and `aria-expanded="false"` to the `.header-menu-btn` elements across all HTML pages. Updated the JS logic in `script.js` and inline scripts to toggle `aria-expanded` dynamically based on the `.header-nav`'s visibility state.

--- a/Portfolio Projects/eaa.html
+++ b/Portfolio Projects/eaa.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -62,12 +62,14 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project1.html
+++ b/Portfolio Projects/project1.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,14 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project3.html
+++ b/Portfolio Projects/project3.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,14 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project4.html
+++ b/Portfolio Projects/project4.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,14 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project5.html
+++ b/Portfolio Projects/project5.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,14 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/Portfolio Projects/project6.html
+++ b/Portfolio Projects/project6.html
@@ -16,8 +16,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="../index.html">Home</a>
             <a href="../about.html">About</a>
             <a href="../galleries.html">Galleries</a>
@@ -47,12 +47,14 @@
     <script src="../script.js"></script>
     <script>
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/about.html
+++ b/about.html
@@ -18,8 +18,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -52,13 +52,15 @@
     <script>
         // Mobile menu toggle
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/bookings.html
+++ b/bookings.html
@@ -190,8 +190,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>

--- a/contact.html
+++ b/contact.html
@@ -175,8 +175,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>

--- a/galleries.html
+++ b/galleries.html
@@ -313,8 +313,8 @@
     <div class="header-left">
       <h1 class="header-title">Caleb Stone</h1>
     </div>
-    <button class="header-menu-btn" aria-label="Menu">Menu</button>
-    <nav class="header-nav">
+    <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+    <nav id="header-nav" class="header-nav">
       <a href="index.html">Home</a>
       <a href="about.html">About</a>
       <a href="galleries.html">Galleries</a>
@@ -810,7 +810,8 @@
   <script>
     // Mobile menu toggle
     document.querySelector('.header-menu-btn').onclick = function () {
-      document.querySelector('.header-nav').classList.toggle('show');
+      const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
     };
 
     // Close mobile menu on link click
@@ -818,6 +819,7 @@
       link.onclick = () => {
         if (window.innerWidth <= 700) {
           document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
         }
       };
     });

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
     <div class="header-left">
       <h1 class="header-title">Caleb Stone</h1>
     </div>
-    <button class="header-menu-btn" aria-label="Menu">Menu</button>
-    <nav class="header-nav">
+    <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+    <nav id="header-nav" class="header-nav">
       <a href="index.html">Home</a>
       <a href="about.html">About</a>
       <a href="galleries.html">Galleries</a>

--- a/portfolio.html
+++ b/portfolio.html
@@ -18,8 +18,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -107,13 +107,15 @@
     <script>
         // Mobile menu toggle
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 1350) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/pricing.html
+++ b/pricing.html
@@ -28,8 +28,8 @@
         <div class="header-left">
             <h1 class="header-title">Caleb Stone</h1>
         </div>
-        <button class="header-menu-btn" aria-label="Menu">Menu</button>
-        <nav class="header-nav">
+        <button class="header-menu-btn" aria-label="Menu" aria-expanded="false" aria-controls="header-nav">Menu</button>
+        <nav id="header-nav" class="header-nav">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="galleries.html">Galleries</a>
@@ -167,13 +167,15 @@
     <script>
         // Mobile menu toggle
         document.querySelector('.header-menu-btn').onclick = function () {
-            document.querySelector('.header-nav').classList.toggle('show');
+            const isExpanded = document.querySelector('.header-nav').classList.toggle('show');
+            document.querySelector('.header-menu-btn').setAttribute('aria-expanded', isExpanded);
         };
         // Optional: close menu when clicking a link (on mobile)
         document.querySelectorAll('.header-nav a').forEach(link => {
             link.onclick = () => {
                 if (window.innerWidth <= 700) {
                     document.querySelector('.header-nav').classList.remove('show');
+                    document.querySelector('.header-menu-btn').setAttribute('aria-expanded', 'false');
                 }
             };
         });

--- a/script.js
+++ b/script.js
@@ -150,7 +150,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
 	if (menuBtn && nav) {
 		menuBtn.onclick = function() {
-			nav.classList.toggle('show');
+			const isExpanded = nav.classList.toggle('show');
+			menuBtn.setAttribute('aria-expanded', isExpanded);
 		};
 
 		// Close menu when clicking a link (on mobile)
@@ -158,6 +159,7 @@ document.addEventListener('DOMContentLoaded', function() {
 			link.onclick = () => {
 				if (window.innerWidth <= 700) {
 					nav.classList.remove('show');
+					menuBtn.setAttribute('aria-expanded', 'false');
 				}
 			};
 		});


### PR DESCRIPTION
💡 **What:** Added `aria-controls="header-nav"` and dynamically toggled `aria-expanded` attributes to the mobile menu toggle button (`.header-menu-btn`) across all pages.
🎯 **Why:** Previously, screen reader users had no programmatic way of knowing if the mobile menu was currently open or closed, nor what element the button controlled. This small change makes the navigation significantly more accessible without altering the visual design.
♿ **Accessibility:** Added proper ARIA state tracking for a critical navigation element.

---
*PR created automatically by Jules for task [14546953123406841609](https://jules.google.com/task/14546953123406841609) started by @calebstone15*