### PR TITLE
🎨 Palette: Add keyboard accessibility to gallery lightboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - [Accessible Lightbox/Gallery Interactions]
+**Learning:** Found that custom lightbox galleries using `div` elements for images (`.gallery-item`) often lack basic keyboard accessibility and screen-reader context.
+**Action:** Always add `tabindex="0"`, `role="button"`, and appropriate `aria-label`s to custom interactive elements. Implement keyboard event listeners for 'Enter', 'Space' (to open), and 'Escape' (to close), alongside visible focus states (`:focus-visible`) for navigation feedback.

--- a/script.js
+++ b/script.js
@@ -172,7 +172,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (lightbox && galleryItems.length > 0) {
         galleryItems.forEach(item => {
-            item.addEventListener('click', () => {
+            item.setAttribute('tabindex', '0');
+            item.setAttribute('role', 'button');
+            item.setAttribute('aria-label', 'View larger image');
+
+            const openLightbox = () => {
                 const img = item.querySelector('img');
                 if (img) {
                     let highResSrc = img.src.split('?')[0];
@@ -182,7 +186,21 @@ document.addEventListener('DOMContentLoaded', () => {
                     lightbox.style.display = "block";
                     document.body.style.overflow = "hidden"; // Prevent scrolling
                 }
+            };
+
+            item.addEventListener('click', openLightbox);
+            item.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openLightbox();
+                }
             });
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && lightbox.style.display === 'block') {
+                window.closeLightbox();
+            }
         });
     }
 });

--- a/styles.css
+++ b/styles.css
@@ -302,12 +302,16 @@ section {
   opacity: 0.9;
 }
 
-.gallery-item:hover, .portfolio-item:hover {
+.gallery-item:hover, .portfolio-item:hover,
+.gallery-item:focus-visible, .portfolio-item:focus-visible {
   transform: translateY(-10px) scale(1.02);
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
 }
 
-.gallery-item:hover img, .portfolio-item:hover img {
+.gallery-item:hover img, .portfolio-item:hover img,
+.gallery-item:focus-visible img, .portfolio-item:focus-visible img {
   transform: scale(1.1);
   opacity: 1;
 }
@@ -461,6 +465,13 @@ footer p {
   font-weight: bold;
   cursor: pointer;
   z-index: 2001;
+  transition: color 0.2s;
+}
+.lightbox-close:hover,
+.lightbox-close:focus-visible {
+  color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
 }
 @keyframes zoomIn {
   from {transform: translate(-50%, -50%) scale(0.9); opacity: 0;}


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility and ARIA roles to the image lightboxes (`.gallery-item` divs) and their close buttons.

🎯 **Why:** Previously, the image galleries used `div` elements with a click listener, making them completely inaccessible to keyboard users and missing context for screen readers. Users couldn't tab to an image, press Enter to open it, or press Escape to close it.

📸 **Verification:** Checked focus states in a browser using Playwright frontend verification. When tabbing to a gallery item or close button, a clear accent-colored outline appears.

♿ **Accessibility:**
- Added `role="button"`, `tabindex="0"`, and `aria-label="View larger image"` to all `.gallery-item` nodes.
- Added `keydown` listeners for 'Enter' and 'Space' to trigger the lightbox natively.
- Added global `keydown` listener for 'Escape' to dismiss the lightbox.
- Implemented `focus-visible` UI outlines.

---
*PR created automatically by Jules for task [12269301740141401331](https://jules.google.com/task/12269301740141401331) started by @calebstone15*